### PR TITLE
Fixed a link with the 3-d portfolio slider links

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -94,7 +94,7 @@ permalink: /about/
         </script>
     <script>
         function navigateToLink() {
-            window.location.href = "/3d-portfolio/about";
+            window.location.href = "/3d-portfolio/#about";
         }
     </script>
 

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -64,7 +64,7 @@ permalink: /contact/
         crossorigin="anonymous"></script>
     <script>
         function navigateToLink() {
-            window.location.href = "/3d-portfolio/contact";
+            window.location.href = "/3d-portfolio/#contact";
         }
     </script>
 </body>


### PR DESCRIPTION
Initially, the 3-d portfolio links were used as 3d-portfolio/about, but it needed to be 3d-portfolio/#about